### PR TITLE
Fix: Sort test runs by newest first

### DIFF
--- a/backend/src/services/TestRunner.ts
+++ b/backend/src/services/TestRunner.ts
@@ -29,7 +29,7 @@ export class TestRunner {
   }
 
   getAllRuns(): TestRun[] {
-    return Array.from(this.runs.values());
+    return Array.from(this.runs.values()).sort((a, b) => b.startTime.getTime() - a.startTime.getTime());
   }
 
   getRun(id: string): TestRun | undefined {


### PR DESCRIPTION
## Summary
- Sort test runs by start time in descending order (newest first)

## Changes
- Modified `TestRunner.getAllRuns()` method to sort runs by `startTime` in descending order
- This ensures the test runs are displayed with the most recent runs at the top

## Test plan
- [x] Build passes without TypeScript errors
- [x] Manual testing: Start multiple test runs and verify they appear sorted by newest first in the UI

Fixes #17