### PR TITLE
feat: implement bulk run functionality for projects and folders

### DIFF
--- a/backend/src/routes/runs.ts
+++ b/backend/src/routes/runs.ts
@@ -116,5 +116,108 @@ export const runRoutes = (testRunner: TestRunner, flowStore?: FlowStore, project
     res.json({ message: 'Run stopped successfully' });
   });
 
+  // Bulk run all flows in a project
+  router.post('/bulk/project/:projectId', async (req: AuthRequest, res) => {
+    const { projectId } = req.params;
+    const { environmentId } = req.body;
+    
+    if (!req.user) {
+      return res.status(401).json({ error: 'Not authenticated' });
+    }
+    
+    try {
+      // Verify user has access to the project
+      if (projectStore) {
+        const project = await projectStore.getProject(projectId);
+        if (!project) {
+          return res.status(404).json({ error: 'Project not found' });
+        }
+        if (project.organizationId !== req.user.organizationId) {
+          return res.status(403).json({ error: 'Access denied' });
+        }
+      }
+      
+      // Get all flows in the project
+      if (!flowStore) {
+        return res.status(500).json({ error: 'Flow store not available' });
+      }
+      
+      const flows = await flowStore.getFlowsByProject(projectId);
+      if (flows.length === 0) {
+        return res.status(404).json({ error: 'No flows found in project' });
+      }
+      
+      // Start runs for all flows
+      const runIds = [];
+      for (const flow of flows) {
+        try {
+          const runId = await testRunner.startRun(flow.id, environmentId, undefined, req.user.organizationId, req.user.userId);
+          runIds.push({ flowId: flow.id, flowName: flow.name, runId });
+        } catch (error) {
+          console.error(`Failed to start run for flow ${flow.id}:`, error);
+          runIds.push({ flowId: flow.id, flowName: flow.name, error: (error as Error).message });
+        }
+      }
+      
+      res.status(201).json({ 
+        message: `Started ${runIds.filter(r => r.runId).length} of ${flows.length} flows`,
+        results: runIds 
+      });
+    } catch (error) {
+      console.error('Failed to start bulk project run:', error);
+      res.status(500).json({ error: (error as Error).message });
+    }
+  });
+
+  // Bulk run all flows in a folder
+  router.post('/bulk/folder/:folderId', async (req: AuthRequest, res) => {
+    const { folderId } = req.params;
+    const { environmentId } = req.body;
+    
+    if (!req.user) {
+      return res.status(401).json({ error: 'Not authenticated' });
+    }
+    
+    try {
+      // Get all flows in the folder
+      if (!flowStore) {
+        return res.status(500).json({ error: 'Flow store not available' });
+      }
+      
+      const flows = await flowStore.getFlowsByFolder(folderId);
+      if (flows.length === 0) {
+        return res.status(404).json({ error: 'No flows found in folder' });
+      }
+      
+      // Verify user has access to the project containing this folder
+      if (flows.length > 0 && flows[0].projectId && projectStore) {
+        const project = await projectStore.getProject(flows[0].projectId);
+        if (project && project.organizationId !== req.user.organizationId) {
+          return res.status(403).json({ error: 'Access denied' });
+        }
+      }
+      
+      // Start runs for all flows
+      const runIds = [];
+      for (const flow of flows) {
+        try {
+          const runId = await testRunner.startRun(flow.id, environmentId, undefined, req.user.organizationId, req.user.userId);
+          runIds.push({ flowId: flow.id, flowName: flow.name, runId });
+        } catch (error) {
+          console.error(`Failed to start run for flow ${flow.id}:`, error);
+          runIds.push({ flowId: flow.id, flowName: flow.name, error: (error as Error).message });
+        }
+      }
+      
+      res.status(201).json({ 
+        message: `Started ${runIds.filter(r => r.runId).length} of ${flows.length} flows`,
+        results: runIds 
+      });
+    } catch (error) {
+      console.error('Failed to start bulk folder run:', error);
+      res.status(500).json({ error: (error as Error).message });
+    }
+  });
+
   return router;
 };

--- a/frontend/src/pages/FlowsOrganizer.tsx
+++ b/frontend/src/pages/FlowsOrganizer.tsx
@@ -5,6 +5,8 @@ import {
   Fab,
   ToggleButton,
   ToggleButtonGroup,
+  Alert,
+  Snackbar,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
@@ -27,6 +29,7 @@ export default function FlowsOrganizer() {
   const [runResultsOpen, setRunResultsOpen] = useState(false);
   const [currentRunId, setCurrentRunId] = useState<string | null>(null);
   const [currentFlowName, setCurrentFlowName] = useState<string>('');
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity?: 'success' | 'info' | 'warning' | 'error' }>({ open: false, message: '' });
 
   useEffect(() => {
     loadData();
@@ -118,6 +121,89 @@ export default function FlowsOrganizer() {
     }
   };
 
+  const handleBulkProjectRun = async (projectId: string) => {
+    const project = projects.find(p => p.id === projectId);
+    const projectName = project?.name || 'Unknown Project';
+    
+    if (!window.confirm(`Are you sure you want to run all flows in project "${projectName}"?`)) {
+      return;
+    }
+    
+    try {
+      const result = await api.startBulkProjectRun(projectId, selectedEnvironment);
+      
+      const successCount = result.results.filter(r => r.runId).length;
+      const failCount = result.results.filter(r => r.error).length;
+      
+      setSnackbar({
+        open: true,
+        message: `Started ${successCount} flow run(s) in project "${projectName}"${failCount > 0 ? `, ${failCount} failed` : ''}`,
+        severity: failCount > 0 ? 'warning' : 'success'
+      });
+      
+      // If any runs started successfully, show results for the first one
+      const firstSuccess = result.results.find(r => r.runId);
+      if (firstSuccess) {
+        setCurrentRunId(firstSuccess.runId!);
+        setCurrentFlowName(`${projectName} - Bulk Run`);
+        setRunResultsOpen(true);
+      }
+      
+    } catch (error) {
+      console.error('Failed to start bulk project run:', error);
+      setSnackbar({
+        open: true,
+        message: `Failed to start bulk run for project "${projectName}": ${error instanceof Error ? error.message : 'Unknown error'}`,
+        severity: 'error'
+      });
+    }
+  };
+
+  const handleBulkFolderRun = async (folderId: string) => {
+    // Find the folder name across all projects
+    let folderName = 'Unknown Folder';
+    for (const projectId in folders) {
+      const folder = folders[projectId].find(f => f.id === folderId);
+      if (folder) {
+        folderName = folder.name;
+        break;
+      }
+    }
+    
+    if (!window.confirm(`Are you sure you want to run all flows in folder "${folderName}"?`)) {
+      return;
+    }
+    
+    try {
+      const result = await api.startBulkFolderRun(folderId, selectedEnvironment);
+      
+      const successCount = result.results.filter(r => r.runId).length;
+      const failCount = result.results.filter(r => r.error).length;
+      
+      setSnackbar({
+        open: true,
+        message: `Started ${successCount} flow run(s) in folder "${folderName}"${failCount > 0 ? `, ${failCount} failed` : ''}`,
+        severity: failCount > 0 ? 'warning' : 'success'
+      });
+      
+      // If any runs started successfully, show results for the first one
+      const firstSuccess = result.results.find(r => r.runId);
+      if (firstSuccess) {
+        setCurrentRunId(firstSuccess.runId!);
+        setCurrentFlowName(`${folderName} - Bulk Run`);
+        setRunResultsOpen(true);
+      }
+      
+    } catch (error) {
+      console.error('Failed to start bulk folder run:', error);
+      setSnackbar({
+        open: true,
+        message: `Failed to start bulk run for folder "${folderName}": ${error instanceof Error ? error.message : 'Unknown error'}`,
+        severity: 'error'
+      });
+    }
+  };
+
   const handleViewModeChange = (_event: React.MouseEvent<HTMLElement>, newMode: 'tree' | 'grid' | null) => {
     if (newMode !== null) {
       setViewMode(newMode);
@@ -172,14 +258,14 @@ export default function FlowsOrganizer() {
         onFlowDuplicate={handleDuplicateFlow}
         onFlowRun={handleRunFlow}
         onFolderCreateFlow={(folderId, projectId) => navigate(`/flows/new?folderId=${folderId}&projectId=${projectId}`)}
-        onFolderRunAllFlows={(folderId) => console.log('Run all flows in folder:', folderId)}
+        onFolderRunAllFlows={handleBulkFolderRun}
         onFolderDuplicate={(folder) => console.log('Duplicate folder:', folder)}
         onFolderDelete={(folderId, folderName, projectId) => console.log('Delete folder:', folderId, folderName, projectId)}
         onFolderImport={(folderId, projectId) => console.log('Import to folder:', folderId, projectId)}
         onFolderExport={(folderId) => console.log('Export folder:', folderId)}
         onProjectCreateFlow={(projectId) => navigate(`/flows/new?projectId=${projectId}`)}
         onProjectCreateFolder={(projectId) => console.log('Create folder in project:', projectId)}
-        onProjectRunAllFlows={(projectId) => console.log('Run all flows in project:', projectId)}
+        onProjectRunAllFlows={handleBulkProjectRun}
         onProjectDuplicate={(project) => console.log('Duplicate project:', project)}
         onProjectDelete={(projectId, projectName) => console.log('Delete project:', projectId, projectName)}
         onProjectImport={(projectId) => console.log('Import to project:', projectId)}
@@ -216,6 +302,21 @@ export default function FlowsOrganizer() {
         runId={currentRunId}
         flowName={currentFlowName}
       />
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={6000}
+        onClose={() => setSnackbar({ ...snackbar, open: false })}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert 
+          onClose={() => setSnackbar({ ...snackbar, open: false })} 
+          severity={snackbar.severity || 'info'}
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -58,6 +58,16 @@ export const api = {
     await apiClient.post(`/runs/${id}/stop`);
   },
 
+  async startBulkProjectRun(projectId: string, environmentId?: string): Promise<{ message: string; results: Array<{ flowId: string; flowName: string; runId?: string; error?: string }> }> {
+    const response = await apiClient.post(`/runs/bulk/project/${projectId}`, { environmentId });
+    return response.data;
+  },
+
+  async startBulkFolderRun(folderId: string, environmentId?: string): Promise<{ message: string; results: Array<{ flowId: string; flowName: string; runId?: string; error?: string }> }> {
+    const response = await apiClient.post(`/runs/bulk/folder/${folderId}`, { environmentId });
+    return response.data;
+  },
+
   async getEnvironments(): Promise<Environment[]> {
     const response = await apiClient.get('/environments');
     return response.data;


### PR DESCRIPTION
## Summary
- Adds bulk run functionality for projects and folders in the file explorer
- Users can now run all flows in a project or folder with a single click
- Replaces console.log placeholders with actual implementation

## Implementation Details
- Added backend endpoints `/runs/bulk/project/:projectId` and `/runs/bulk/folder/:folderId`
- Added frontend API methods `startBulkProjectRun` and `startBulkFolderRun`
- Updated FlowsOrganizer component to handle bulk operations
- Added Snackbar notifications for user feedback
- Includes confirmation dialogs and comprehensive error handling

## Test Plan
- [x] Verify bulk project run endpoint works correctly
- [x] Verify bulk folder run endpoint works correctly
- [x] Confirm user feedback notifications display properly
- [x] Test error handling for failed runs
- [x] Verify TypeScript compilation succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)