### PR TITLE
feat: implement project-wide OpenAPI schema management

### DIFF
--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -108,6 +108,21 @@ async function initializeDatabase() {
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
       UNIQUE(project_id, user_id)
     );
+
+    CREATE TABLE IF NOT EXISTS project_openapi_schemas (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      description TEXT,
+      version TEXT NOT NULL,
+      title TEXT NOT NULL,
+      base_url TEXT,
+      schema TEXT NOT NULL,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+      UNIQUE(project_id, name)
+    );
   `);
   
   // Create default environment if none exists

--- a/backend/src/db/mongodb.ts
+++ b/backend/src/db/mongodb.ts
@@ -1,5 +1,5 @@
 import { MongoClient, Db, Collection } from 'mongodb';
-import { TestFlow, TestRun, Environment, EnvironmentVariable, Project, Folder, User, Organization, Team, TeamUser, ProjectTeam } from '../../../shared/src/types';
+import { TestFlow, TestRun, Environment, EnvironmentVariable, Project, Folder, User, Organization, Team, TeamUser, ProjectTeam, ProjectOpenAPISchema } from '../../../shared/src/types';
 
 export interface DbCollections {
   flows: Collection<TestFlow>;
@@ -14,6 +14,7 @@ export interface DbCollections {
   teams: Collection<Team>;
   teamUsers: Collection<TeamUser>;
   projectTeams: Collection<ProjectTeam>;
+  projectOpenAPISchemas: Collection<ProjectOpenAPISchema>;
 }
 
 export class MongoDB {
@@ -45,6 +46,7 @@ export class MongoDB {
       teams: this.db.collection<Team>('teams'),
       teamUsers: this.db.collection<TeamUser>('teamUsers'),
       projectTeams: this.db.collection<ProjectTeam>('projectTeams'),
+      projectOpenAPISchemas: this.db.collection<ProjectOpenAPISchema>('projectOpenAPISchemas'),
     };
   }
 

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -200,3 +200,93 @@ projectRoutes.delete('/:id/teams/:teamId', async (req, res) => {
     res.status(500).json({ error: 'Failed to remove team from project' });
   }
 });
+
+// OpenAPI Schema routes
+projectRoutes.get('/:id/openapi-schemas', async (req, res) => {
+  try {
+    const schemas = await projectStore.getOpenAPISchemas(req.params.id);
+    res.json(schemas);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch OpenAPI schemas' });
+  }
+});
+
+projectRoutes.post('/:id/openapi-schemas', async (req, res) => {
+  try {
+    const { name, description, version, title, baseUrl, schema } = req.body;
+    if (!name || !version || !title || !schema) {
+      return res.status(400).json({ error: 'name, version, title, and schema are required' });
+    }
+    
+    const openApiSchema = await projectStore.createOpenAPISchema({
+      projectId: req.params.id,
+      name,
+      description,
+      version,
+      title,
+      baseUrl,
+      schema
+    });
+    res.status(201).json(openApiSchema);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to create OpenAPI schema' });
+  }
+});
+
+projectRoutes.put('/:id/openapi-schemas/:schemaId', async (req, res) => {
+  try {
+    const { name, description, version, title, baseUrl, schema } = req.body;
+    const openApiSchema = await projectStore.updateOpenAPISchema(req.params.schemaId, {
+      name,
+      description,
+      version,
+      title,
+      baseUrl,
+      schema
+    });
+    
+    if (!openApiSchema) {
+      return res.status(404).json({ error: 'OpenAPI schema not found' });
+    }
+    
+    res.json(openApiSchema);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to update OpenAPI schema' });
+  }
+});
+
+projectRoutes.delete('/:id/openapi-schemas/:schemaId', async (req, res) => {
+  try {
+    const success = await projectStore.deleteOpenAPISchema(req.params.schemaId);
+    if (!success) {
+      return res.status(404).json({ error: 'OpenAPI schema not found' });
+    }
+    res.status(204).send();
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to delete OpenAPI schema' });
+  }
+});
+
+projectRoutes.post('/:id/openapi-schemas/:schemaId/generate-flows', async (req, res) => {
+  try {
+    const { selectedOperations, baseUrlOverride, folderId } = req.body;
+    if (!selectedOperations || selectedOperations.length === 0) {
+      return res.status(400).json({ error: 'selectedOperations is required' });
+    }
+    
+    const schema = await projectStore.getOpenAPISchema(req.params.schemaId);
+    if (!schema) {
+      return res.status(404).json({ error: 'OpenAPI schema not found' });
+    }
+    
+    const flows = await projectStore.generateFlowsFromOpenAPISchema(
+      req.params.schemaId,
+      selectedOperations,
+      baseUrlOverride,
+      folderId
+    );
+    res.status(201).json(flows);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to generate flows from OpenAPI schema' });
+  }
+});

--- a/backend/src/services/ProjectStore.ts
+++ b/backend/src/services/ProjectStore.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
-import { Project, Folder } from '../../../shared/src/types';
+import { Project, Folder, ProjectOpenAPISchema, TestFlow, TestStep } from '../../../shared/src/types';
 import { getDatabase } from '../db/database';
+import { parseOpenAPISchema, generateStepsFromOpenAPI } from '../../../shared/src/openApiParser';
 
 export class ProjectStore {
   // Projects
@@ -192,5 +193,181 @@ export class ProjectStore {
     // Since SQLite version doesn't have organization support,
     // we return all projects for now
     return this.getProjects();
+  }
+
+  // OpenAPI Schema management methods (SQLite implementation)
+  async getOpenAPISchemas(projectId: string): Promise<ProjectOpenAPISchema[]> {
+    const db = await getDatabase();
+    const rows = await db.all(
+      'SELECT * FROM project_openapi_schemas WHERE project_id = ? ORDER BY name',
+      projectId
+    );
+    return rows.map(row => ({
+      id: row.id,
+      projectId: row.project_id,
+      name: row.name,
+      description: row.description,
+      version: row.version,
+      title: row.title,
+      baseUrl: row.base_url,
+      schema: JSON.parse(row.schema),
+      createdAt: new Date(row.created_at),
+      updatedAt: new Date(row.updated_at)
+    }));
+  }
+
+  async getOpenAPISchema(schemaId: string): Promise<ProjectOpenAPISchema | undefined> {
+    const db = await getDatabase();
+    const row = await db.get('SELECT * FROM project_openapi_schemas WHERE id = ?', schemaId);
+    if (!row) return undefined;
+    
+    return {
+      id: row.id,
+      projectId: row.project_id,
+      name: row.name,
+      description: row.description,
+      version: row.version,
+      title: row.title,
+      baseUrl: row.base_url,
+      schema: JSON.parse(row.schema),
+      createdAt: new Date(row.created_at),
+      updatedAt: new Date(row.updated_at)
+    };
+  }
+
+  async createOpenAPISchema(data: Partial<ProjectOpenAPISchema>): Promise<ProjectOpenAPISchema> {
+    const db = await getDatabase();
+    const id = uuidv4();
+    const now = new Date();
+    
+    await db.run(
+      `INSERT INTO project_openapi_schemas 
+       (id, project_id, name, description, version, title, base_url, schema, created_at, updated_at) 
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id,
+        data.projectId,
+        data.name,
+        data.description || null,
+        data.version,
+        data.title,
+        data.baseUrl || null,
+        JSON.stringify(data.schema),
+        now.toISOString(),
+        now.toISOString()
+      ]
+    );
+    
+    return {
+      id,
+      projectId: data.projectId!,
+      name: data.name!,
+      description: data.description,
+      version: data.version!,
+      title: data.title!,
+      baseUrl: data.baseUrl,
+      schema: data.schema!,
+      createdAt: now,
+      updatedAt: now
+    };
+  }
+
+  async updateOpenAPISchema(schemaId: string, data: Partial<ProjectOpenAPISchema>): Promise<ProjectOpenAPISchema | undefined> {
+    const db = await getDatabase();
+    const now = new Date();
+    
+    const updateData: any = {
+      updated_at: now.toISOString()
+    };
+    
+    if (data.name !== undefined) updateData.name = data.name;
+    if (data.description !== undefined) updateData.description = data.description;
+    if (data.version !== undefined) updateData.version = data.version;
+    if (data.title !== undefined) updateData.title = data.title;
+    if (data.baseUrl !== undefined) updateData.base_url = data.baseUrl;
+    if (data.schema !== undefined) updateData.schema = JSON.stringify(data.schema);
+    
+    const setClause = Object.keys(updateData).map(key => `${key} = ?`).join(', ');
+    const values = Object.values(updateData);
+    values.push(schemaId);
+    
+    const result = await db.run(
+      `UPDATE project_openapi_schemas SET ${setClause} WHERE id = ?`,
+      values
+    );
+    
+    if ((result.changes || 0) === 0) {
+      return undefined;
+    }
+    
+    return await this.getOpenAPISchema(schemaId);
+  }
+
+  async deleteOpenAPISchema(schemaId: string): Promise<boolean> {
+    const db = await getDatabase();
+    const result = await db.run('DELETE FROM project_openapi_schemas WHERE id = ?', schemaId);
+    return (result.changes || 0) > 0;
+  }
+
+  async generateFlowsFromOpenAPISchema(
+    schemaId: string,
+    selectedOperations: string[],
+    baseUrlOverride?: string,
+    folderId?: string
+  ): Promise<TestFlow[]> {
+    const schema = await this.getOpenAPISchema(schemaId);
+    if (!schema) {
+      throw new Error('OpenAPI schema not found');
+    }
+
+    const parsedAPI = parseOpenAPISchema(schema.schema);
+    const steps = generateStepsFromOpenAPI(parsedAPI, selectedOperations, baseUrlOverride);
+    
+    // Create flows for each operation
+    const flows: TestFlow[] = [];
+    const db = await getDatabase();
+    
+    for (const operation of selectedOperations) {
+      const operationSteps = steps.filter(step => 
+        step.name.includes(operation) || step.config?.url?.includes(operation.split(' ')[1])
+      );
+      
+      if (operationSteps.length > 0) {
+        const flowId = uuidv4();
+        const now = new Date();
+        
+        const flow: TestFlow = {
+          id: flowId,
+          projectId: schema.projectId,
+          folderId,
+          name: `${parsedAPI.title} - ${operation}`,
+          description: `Generated from OpenAPI schema: ${schema.name}`,
+          steps: operationSteps,
+          connections: [],
+          createdAt: now,
+          updatedAt: now,
+        };
+        
+        // Insert flow into database
+        await db.run(
+          `INSERT INTO flows (id, project_id, folder_id, name, description, steps, created_at, updated_at) 
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            flowId,
+            schema.projectId,
+            folderId || null,
+            flow.name,
+            flow.description,
+            JSON.stringify(operationSteps),
+            now.toISOString(),
+            now.toISOString()
+          ]
+        );
+        
+        flows.push(flow);
+      }
+    }
+    
+    return flows;
   }
 }

--- a/backend/src/services/ProjectStoreMongo.ts
+++ b/backend/src/services/ProjectStoreMongo.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
-import { Project, Folder, FolderTree } from '../../../shared/src/types';
+import { Project, Folder, FolderTree, ProjectOpenAPISchema, TestFlow, TestStep } from '../../../shared/src/types';
 import { MongoDB } from '../db/mongodb';
+import { parseOpenAPISchema, generateStepsFromOpenAPI } from '../../../shared/src/openApiParser';
 
 export class ProjectStore {
   private mongodb: MongoDB;
@@ -222,6 +223,132 @@ export class ProjectStore {
     } catch (error) {
       console.error('Failed to get projects by organization:', error);
       return [];
+    }
+  }
+
+  // OpenAPI Schema management methods
+  async getOpenAPISchemas(projectId: string): Promise<ProjectOpenAPISchema[]> {
+    try {
+      const collections = this.mongodb.getCollections();
+      const schemas = await collections.projectOpenAPISchemas.find({ projectId }).toArray();
+      return schemas;
+    } catch (error) {
+      console.error('Failed to get OpenAPI schemas:', error);
+      return [];
+    }
+  }
+
+  async getOpenAPISchema(schemaId: string): Promise<ProjectOpenAPISchema | undefined> {
+    try {
+      const collections = this.mongodb.getCollections();
+      const schema = await collections.projectOpenAPISchemas.findOne({ id: schemaId });
+      return schema || undefined;
+    } catch (error) {
+      console.error('Failed to get OpenAPI schema:', error);
+      return undefined;
+    }
+  }
+
+  async createOpenAPISchema(data: Partial<ProjectOpenAPISchema>): Promise<ProjectOpenAPISchema> {
+    const schema: ProjectOpenAPISchema = {
+      id: data.id || uuidv4(),
+      projectId: data.projectId!,
+      name: data.name!,
+      description: data.description,
+      version: data.version!,
+      title: data.title!,
+      baseUrl: data.baseUrl,
+      schema: data.schema!,
+      createdAt: data.createdAt || new Date(),
+      updatedAt: data.updatedAt || new Date(),
+    };
+
+    try {
+      const collections = this.mongodb.getCollections();
+      await collections.projectOpenAPISchemas.insertOne(schema);
+      return schema;
+    } catch (error) {
+      console.error('Failed to create OpenAPI schema:', error);
+      throw error;
+    }
+  }
+
+  async updateOpenAPISchema(schemaId: string, data: Partial<ProjectOpenAPISchema>): Promise<ProjectOpenAPISchema | undefined> {
+    try {
+      const collections = this.mongodb.getCollections();
+      const result = await collections.projectOpenAPISchemas.updateOne(
+        { id: schemaId },
+        { $set: { ...data, updatedAt: new Date() } }
+      );
+
+      if (result.matchedCount === 0) {
+        return undefined;
+      }
+
+      return await this.getOpenAPISchema(schemaId);
+    } catch (error) {
+      console.error('Failed to update OpenAPI schema:', error);
+      throw error;
+    }
+  }
+
+  async deleteOpenAPISchema(schemaId: string): Promise<boolean> {
+    try {
+      const collections = this.mongodb.getCollections();
+      const result = await collections.projectOpenAPISchemas.deleteOne({ id: schemaId });
+      return result.deletedCount > 0;
+    } catch (error) {
+      console.error('Failed to delete OpenAPI schema:', error);
+      return false;
+    }
+  }
+
+  async generateFlowsFromOpenAPISchema(
+    schemaId: string,
+    selectedOperations: string[],
+    baseUrlOverride?: string,
+    folderId?: string
+  ): Promise<TestFlow[]> {
+    try {
+      const schema = await this.getOpenAPISchema(schemaId);
+      if (!schema) {
+        throw new Error('OpenAPI schema not found');
+      }
+
+      const parsedAPI = parseOpenAPISchema(schema.schema);
+      const steps = generateStepsFromOpenAPI(parsedAPI, selectedOperations, baseUrlOverride);
+      
+      // Create flows for each operation
+      const flows: TestFlow[] = [];
+      const collections = this.mongodb.getCollections();
+      
+      for (const operation of selectedOperations) {
+        const operationSteps = steps.filter(step => 
+          step.name.includes(operation) || step.config?.url?.includes(operation.split(' ')[1])
+        );
+        
+        if (operationSteps.length > 0) {
+          const flow: TestFlow = {
+            id: uuidv4(),
+            projectId: schema.projectId,
+            folderId,
+            name: `${parsedAPI.title} - ${operation}`,
+            description: `Generated from OpenAPI schema: ${schema.name}`,
+            steps: operationSteps,
+            connections: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          };
+          
+          await collections.flows.insertOne(flow);
+          flows.push(flow);
+        }
+      }
+      
+      return flows;
+    } catch (error) {
+      console.error('Failed to generate flows from OpenAPI schema:', error);
+      throw error;
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "react-flow-renderer": "^10.3.17",
     "react-router-dom": "^6.30.1",
     "socket.io-client": "^4.7.2",
-    "uuid": "^11.1.0"
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.5",
@@ -34,10 +34,10 @@
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "@vitejs/plugin-react": "^4.2.1",
-    "@vitest/coverage-v8": "^1.0.4",
+    "@vitest/coverage-v8": "^3.2.4",
     "jsdom": "^23.0.1",
     "typescript": "^5.3.3",
-    "vite": "^5.0.10",
-    "vitest": "^1.0.4"
+    "vite": "^6.3.5",
+    "vitest": "^3.2.4"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc --project . && vite build",
+    "build": "cd ../shared && npm install && npm run build && cd ../frontend && tsc --project . && vite build",
+    "build:standalone": "tsc --project . && vite build",
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc --project . && vite build",
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",

--- a/frontend/src/components/OpenAPIGenerateFlowsDialog.tsx
+++ b/frontend/src/components/OpenAPIGenerateFlowsDialog.tsx
@@ -1,0 +1,268 @@
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Checkbox,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  TextField,
+  Alert,
+  CircularProgress,
+} from '@mui/material';
+import { ProjectOpenAPISchema, Folder } from '../../../shared/src/types';
+import { api } from '../services/api';
+import { parseOpenAPISchema, OpenAPIOperation } from '../../../shared/src/openApiParser';
+
+interface OpenAPIGenerateFlowsDialogProps {
+  open: boolean;
+  onClose: (generated?: boolean) => void;
+  projectId: string;
+  schema: ProjectOpenAPISchema;
+  projectFolders: Folder[];
+}
+
+export default function OpenAPIGenerateFlowsDialog({
+  open,
+  onClose,
+  projectId,
+  schema,
+  projectFolders,
+}: OpenAPIGenerateFlowsDialogProps) {
+  const [operations, setOperations] = useState<OpenAPIOperation[]>([]);
+  const [selectedOperations, setSelectedOperations] = useState<string[]>([]);
+  const [selectedFolder, setSelectedFolder] = useState<string>('');
+  const [baseUrlOverride, setBaseUrlOverride] = useState<string>('');
+  const [servers, setServers] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (open && schema) {
+      try {
+        const parsed = parseOpenAPISchema(schema.schema);
+        setOperations(parsed.operations);
+        setServers(parsed.servers);
+        setBaseUrlOverride(schema.baseUrl || (parsed.servers.length > 0 ? parsed.servers[0] : ''));
+        
+        // Pre-select all operations
+        const allOperations = parsed.operations.map(op => `${op.method} ${op.path}`);
+        setSelectedOperations(allOperations);
+      } catch (err) {
+        setError('Failed to parse OpenAPI schema');
+      }
+    }
+  }, [open, schema]);
+
+  const handleToggleOperation = (operation: string) => {
+    setSelectedOperations(prev => {
+      if (prev.includes(operation)) {
+        return prev.filter(op => op !== operation);
+      } else {
+        return [...prev, operation];
+      }
+    });
+  };
+
+  const handleSelectAll = () => {
+    const allOperations = operations.map(op => `${op.method} ${op.path}`);
+    setSelectedOperations(allOperations);
+  };
+
+  const handleDeselectAll = () => {
+    setSelectedOperations([]);
+  };
+
+  const handleGenerate = async () => {
+    if (selectedOperations.length === 0) {
+      setError('Please select at least one operation');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+
+    try {
+      await api.generateFlowsFromOpenAPISchema(
+        projectId,
+        schema.id,
+        selectedOperations,
+        baseUrlOverride || undefined,
+        selectedFolder || undefined
+      );
+      onClose(true);
+    } catch (err) {
+      setError(`Failed to generate flows: ${(err as Error).message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getMethodColor = (method: string): string => {
+    switch (method.toUpperCase()) {
+      case 'GET': return '#61affe';
+      case 'POST': return '#49cc90';
+      case 'PUT': return '#fca130';
+      case 'DELETE': return '#f93e3e';
+      case 'PATCH': return '#50e3c2';
+      default: return '#9012fe';
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={() => onClose(false)} maxWidth="md" fullWidth>
+      <DialogTitle>
+        Generate Flows from "{schema?.name}"
+      </DialogTitle>
+
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          Select operations to generate flows for. Each operation will create a separate flow.
+        </Typography>
+
+        <Box sx={{ mb: 3 }}>
+          <FormControl fullWidth margin="normal">
+            <InputLabel>Target Folder (Optional)</InputLabel>
+            <Select
+              value={selectedFolder}
+              onChange={(e) => setSelectedFolder(e.target.value)}
+              label="Target Folder (Optional)"
+            >
+              <MenuItem value="">
+                <em>Root Project (No Folder)</em>
+              </MenuItem>
+              {projectFolders.map((folder) => (
+                <MenuItem key={folder.id} value={folder.id}>
+                  {folder.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl fullWidth margin="normal">
+            <InputLabel>Base URL</InputLabel>
+            <Select
+              value={baseUrlOverride}
+              onChange={(e) => setBaseUrlOverride(e.target.value)}
+              label="Base URL"
+            >
+              {servers.map((server, index) => (
+                <MenuItem key={index} value={server}>
+                  {server}
+                </MenuItem>
+              ))}
+              <MenuItem value="">
+                <em>Custom</em>
+              </MenuItem>
+            </Select>
+          </FormControl>
+
+          {baseUrlOverride === '' && (
+            <TextField
+              fullWidth
+              label="Custom Base URL"
+              placeholder="{{baseUrl}} or https://api.example.com"
+              value={baseUrlOverride}
+              onChange={(e) => setBaseUrlOverride(e.target.value)}
+              margin="normal"
+              helperText="Use environment variables like {{baseUrl}}"
+            />
+          )}
+        </Box>
+
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+          <Typography variant="subtitle1">
+            Select Operations ({selectedOperations.length}/{operations.length})
+          </Typography>
+          <Box>
+            <Button size="small" onClick={handleSelectAll}>
+              Select All
+            </Button>
+            <Button size="small" onClick={handleDeselectAll}>
+              Deselect All
+            </Button>
+          </Box>
+        </Box>
+
+        <List sx={{ maxHeight: 400, overflow: 'auto', border: 1, borderColor: 'divider', borderRadius: 1 }}>
+          {operations.map((operation, index) => {
+            const operationId = `${operation.method} ${operation.path}`;
+            const isSelected = selectedOperations.includes(operationId);
+            
+            return (
+              <ListItem key={index} disablePadding>
+                <ListItemButton onClick={() => handleToggleOperation(operationId)}>
+                  <ListItemIcon>
+                    <Checkbox
+                      edge="start"
+                      checked={isSelected}
+                      tabIndex={-1}
+                      disableRipple
+                    />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={
+                      <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                        <Typography
+                          variant="caption"
+                          sx={{
+                            px: 1,
+                            py: 0.5,
+                            borderRadius: 1,
+                            bgcolor: getMethodColor(operation.method),
+                            color: 'white',
+                            fontWeight: 'bold',
+                            minWidth: 60,
+                            textAlign: 'center',
+                          }}
+                        >
+                          {operation.method}
+                        </Typography>
+                        <Typography variant="body2">{operation.path}</Typography>
+                      </Box>
+                    }
+                    secondary={operation.summary || operation.operationId || operation.description}
+                  />
+                </ListItemButton>
+              </ListItem>
+            );
+          })}
+        </List>
+
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={() => onClose(false)} disabled={loading}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleGenerate}
+          variant="contained"
+          disabled={loading || selectedOperations.length === 0}
+        >
+          {loading ? (
+            <CircularProgress size={20} />
+          ) : (
+            `Generate ${selectedOperations.length} Flow${selectedOperations.length !== 1 ? 's' : ''}`
+          )}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/OpenAPIImportDialog.tsx
+++ b/frontend/src/components/OpenAPIImportDialog.tsx
@@ -25,7 +25,7 @@ import {
 } from '@mui/material';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
 import LinkIcon from '@mui/icons-material/Link';
-import { parseOpenAPISchema, generateStepsFromOpenAPI, ParsedOpenAPI } from '../utils/openApiParser';
+import { parseOpenAPISchema, generateStepsFromOpenAPI, ParsedOpenAPI } from '../../../shared/src/openApiParser';
 import { TestStep } from '../../../shared/src/types';
 
 interface OpenAPIImportDialogProps {

--- a/frontend/src/components/OpenAPIImportDialog.tsx
+++ b/frontend/src/components/OpenAPIImportDialog.tsx
@@ -22,16 +22,21 @@ import {
   MenuItem,
   Tabs,
   Tab,
+  FormControlLabel,
+  Checkbox as MuiCheckbox,
+  Divider,
 } from '@mui/material';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
 import LinkIcon from '@mui/icons-material/Link';
 import { parseOpenAPISchema, generateStepsFromOpenAPI, ParsedOpenAPI } from '../../../shared/src/openApiParser';
 import { TestStep } from '../../../shared/src/types';
+import { api } from '../services/api';
 
 interface OpenAPIImportDialogProps {
   open: boolean;
   onClose: () => void;
   onImport: (steps: TestStep[]) => void;
+  projectId?: string; // Optional: if provided, show option to save schema
 }
 
 interface TabPanelProps {
@@ -49,7 +54,7 @@ function TabPanel(props: TabPanelProps) {
   );
 }
 
-export default function OpenAPIImportDialog({ open, onClose, onImport }: OpenAPIImportDialogProps) {
+export default function OpenAPIImportDialog({ open, onClose, onImport, projectId }: OpenAPIImportDialogProps) {
   const [activeTab, setActiveTab] = useState(0);
   const [schemaText, setSchemaText] = useState('');
   const [schemaUrl, setSchemaUrl] = useState('');
@@ -58,6 +63,9 @@ export default function OpenAPIImportDialog({ open, onClose, onImport }: OpenAPI
   const [parsedAPI, setParsedAPI] = useState<ParsedOpenAPI | null>(null);
   const [selectedOperations, setSelectedOperations] = useState<string[]>([]);
   const [baseUrlOverride, setBaseUrlOverride] = useState('');
+  const [saveSchema, setSaveSchema] = useState(false);
+  const [schemaName, setSchemaName] = useState('');
+  const [schemaDescription, setSchemaDescription] = useState('');
 
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -113,6 +121,10 @@ export default function OpenAPIImportDialog({ open, onClose, onImport }: OpenAPI
       if (parsed.servers.length > 0) {
         setBaseUrlOverride(parsed.servers[0]);
       }
+      
+      // Auto-populate schema name
+      setSchemaName(parsed.title || '');
+      setSchemaDescription('');
     } catch (err) {
       setError(`Failed to parse schema: ${(err as Error).message}`);
       setParsedAPI(null);
@@ -140,17 +152,35 @@ export default function OpenAPIImportDialog({ open, onClose, onImport }: OpenAPI
     setSelectedOperations([]);
   };
 
-  const handleImport = () => {
+  const handleImport = async () => {
     if (!parsedAPI) return;
 
-    const steps = generateStepsFromOpenAPI(
-      parsedAPI,
-      selectedOperations,
-      baseUrlOverride || undefined
-    );
+    try {
+      // Save schema if requested and projectId is available
+      if (saveSchema && projectId && schemaName.trim()) {
+        const schemaData = {
+          name: schemaName.trim(),
+          description: schemaDescription.trim() || undefined,
+          version: parsedAPI.version,
+          title: parsedAPI.title,
+          baseUrl: baseUrlOverride || undefined,
+          schema: JSON.parse(schemaText), // Use original schema text
+        };
 
-    onImport(steps);
-    handleClose();
+        await api.createProjectOpenAPISchema(projectId, schemaData);
+      }
+
+      const steps = generateStepsFromOpenAPI(
+        parsedAPI,
+        selectedOperations,
+        baseUrlOverride || undefined
+      );
+
+      onImport(steps);
+      handleClose();
+    } catch (err) {
+      setError(`Failed to save schema: ${(err as Error).message}`);
+    }
   };
 
   const handleClose = () => {
@@ -161,6 +191,9 @@ export default function OpenAPIImportDialog({ open, onClose, onImport }: OpenAPI
     setParsedAPI(null);
     setSelectedOperations([]);
     setBaseUrlOverride('');
+    setSaveSchema(false);
+    setSchemaName('');
+    setSchemaDescription('');
     onClose();
   };
 
@@ -260,6 +293,46 @@ export default function OpenAPIImportDialog({ open, onClose, onImport }: OpenAPI
               />
             )}
 
+            {projectId && (
+              <>
+                <Divider sx={{ my: 2 }} />
+                <FormControlLabel
+                  control={
+                    <MuiCheckbox
+                      checked={saveSchema}
+                      onChange={(e) => setSaveSchema(e.target.checked)}
+                    />
+                  }
+                  label="Save schema to project for reuse"
+                />
+                {saveSchema && (
+                  <Box sx={{ mt: 2 }}>
+                    <TextField
+                      fullWidth
+                      label="Schema Name"
+                      value={schemaName}
+                      onChange={(e) => setSchemaName(e.target.value)}
+                      placeholder="My API Schema"
+                      margin="normal"
+                      size="small"
+                      required
+                    />
+                    <TextField
+                      fullWidth
+                      label="Description (Optional)"
+                      value={schemaDescription}
+                      onChange={(e) => setSchemaDescription(e.target.value)}
+                      placeholder="Description of this API schema"
+                      margin="normal"
+                      size="small"
+                      multiline
+                      rows={2}
+                    />
+                  </Box>
+                )}
+              </>
+            )}
+
             <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2, mb: 1 }}>
               <Typography variant="subtitle1">
                 Select Operations ({selectedOperations.length}/{parsedAPI.operations.length})
@@ -325,7 +398,11 @@ export default function OpenAPIImportDialog({ open, onClose, onImport }: OpenAPI
         <Button
           onClick={handleImport}
           variant="contained"
-          disabled={!parsedAPI || selectedOperations.length === 0}
+          disabled={
+            !parsedAPI || 
+            selectedOperations.length === 0 || 
+            (saveSchema && !schemaName.trim())
+          }
         >
           Import {selectedOperations.length} Operation{selectedOperations.length !== 1 ? 's' : ''}
         </Button>

--- a/frontend/src/components/OpenAPISchemaDialog.tsx
+++ b/frontend/src/components/OpenAPISchemaDialog.tsx
@@ -1,0 +1,375 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Box,
+  Typography,
+  Alert,
+  CircularProgress,
+  Tabs,
+  Tab,
+} from '@mui/material';
+import UploadFileIcon from '@mui/icons-material/UploadFile';
+import LinkIcon from '@mui/icons-material/Link';
+import { ProjectOpenAPISchema } from '../../../shared/src/types';
+import { api } from '../services/api';
+import { parseOpenAPISchema } from '../../../shared/src/openApiParser';
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function TabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+  return (
+    <div role="tabpanel" hidden={value !== index} {...other}>
+      {value === index && <Box sx={{ p: 2 }}>{children}</Box>}
+    </div>
+  );
+}
+
+interface OpenAPISchemaDialogProps {
+  open: boolean;
+  onClose: (saved?: boolean) => void;
+  projectId: string;
+  schema?: ProjectOpenAPISchema | null;
+}
+
+export default function OpenAPISchemaDialog({
+  open,
+  onClose,
+  projectId,
+  schema,
+}: OpenAPISchemaDialogProps) {
+  const [activeTab, setActiveTab] = useState(0);
+  const [formData, setFormData] = useState({
+    name: '',
+    description: '',
+    version: '',
+    title: '',
+    baseUrl: '',
+    schemaText: '',
+    schemaUrl: '',
+  });
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [parsedSchema, setParsedSchema] = useState<any>(null);
+
+  const isEditing = Boolean(schema);
+
+  useEffect(() => {
+    if (schema) {
+      setFormData({
+        name: schema.name,
+        description: schema.description || '',
+        version: schema.version,
+        title: schema.title,
+        baseUrl: schema.baseUrl || '',
+        schemaText: JSON.stringify(schema.schema, null, 2),
+        schemaUrl: '',
+      });
+      setParsedSchema(schema.schema);
+    } else {
+      setFormData({
+        name: '',
+        description: '',
+        version: '',
+        title: '',
+        baseUrl: '',
+        schemaText: '',
+        schemaUrl: '',
+      });
+      setParsedSchema(null);
+    }
+    setError('');
+    setActiveTab(0);
+  }, [schema, open]);
+
+  const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const content = e.target?.result as string;
+      setFormData(prev => ({ ...prev, schemaText: content }));
+      parseSchemaText(content);
+    };
+    reader.readAsText(file);
+  };
+
+  const handleUrlLoad = async () => {
+    if (!formData.schemaUrl) {
+      setError('Please enter a URL');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+
+    try {
+      // Use proxy endpoint to avoid CORS issues
+      const proxyUrl = `/api/proxy?url=${encodeURIComponent(formData.schemaUrl)}`;
+      const response = await fetch(proxyUrl);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch: ${response.statusText}`);
+      }
+      const text = await response.text();
+      setFormData(prev => ({ ...prev, schemaText: text }));
+      parseSchemaText(text);
+    } catch (err) {
+      setError(`Failed to load schema: ${(err as Error).message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const parseSchemaText = (text: string) => {
+    try {
+      const schema = JSON.parse(text);
+      const parsed = parseOpenAPISchema(schema);
+      setParsedSchema(schema);
+      
+      // Auto-populate form fields if not editing
+      if (!isEditing) {
+        setFormData(prev => ({
+          ...prev,
+          title: parsed.title || prev.title,
+          version: parsed.version || prev.version,
+          baseUrl: parsed.servers.length > 0 ? parsed.servers[0] : prev.baseUrl,
+          name: prev.name || parsed.title || '',
+        }));
+      }
+      
+      setError('');
+    } catch (err) {
+      setError(`Failed to parse schema: ${(err as Error).message}`);
+      setParsedSchema(null);
+    }
+  };
+
+  const handleSchemaTextChange = (value: string) => {
+    setFormData(prev => ({ ...prev, schemaText: value }));
+    if (value.trim()) {
+      parseSchemaText(value);
+    } else {
+      setParsedSchema(null);
+    }
+  };
+
+  const handleSave = async () => {
+    // Validation
+    if (!formData.name.trim()) {
+      setError('Schema name is required');
+      return;
+    }
+    if (!formData.version.trim()) {
+      setError('Version is required');
+      return;
+    }
+    if (!formData.title.trim()) {
+      setError('Title is required');
+      return;
+    }
+    if (!parsedSchema) {
+      setError('Valid OpenAPI schema is required');
+      return;
+    }
+
+    setSaving(true);
+    setError('');
+
+    try {
+      const schemaData = {
+        name: formData.name.trim(),
+        description: formData.description.trim() || undefined,
+        version: formData.version.trim(),
+        title: formData.title.trim(),
+        baseUrl: formData.baseUrl.trim() || undefined,
+        schema: parsedSchema,
+      };
+
+      if (isEditing) {
+        await api.updateProjectOpenAPISchema(projectId, schema!.id, schemaData);
+      } else {
+        await api.createProjectOpenAPISchema(projectId, schemaData);
+      }
+
+      onClose(true);
+    } catch (err) {
+      setError(`Failed to save schema: ${(err as Error).message}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClose = () => {
+    onClose(false);
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
+      <DialogTitle>
+        {isEditing ? 'Edit OpenAPI Schema' : 'Add OpenAPI Schema'}
+      </DialogTitle>
+
+      <DialogContent>
+        <Box sx={{ mb: 3 }}>
+          <TextField
+            fullWidth
+            label="Schema Name"
+            value={formData.name}
+            onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
+            margin="normal"
+            required
+            placeholder="My API Schema"
+          />
+          
+          <TextField
+            fullWidth
+            label="Description"
+            value={formData.description}
+            onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
+            margin="normal"
+            multiline
+            rows={2}
+            placeholder="Description of this API schema"
+          />
+
+          <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
+            <TextField
+              label="Version"
+              value={formData.version}
+              onChange={(e) => setFormData(prev => ({ ...prev, version: e.target.value }))}
+              required
+              placeholder="1.0.0"
+              sx={{ flex: 1 }}
+            />
+            
+            <TextField
+              label="Title"
+              value={formData.title}
+              onChange={(e) => setFormData(prev => ({ ...prev, title: e.target.value }))}
+              required
+              placeholder="API Title"
+              sx={{ flex: 2 }}
+            />
+          </Box>
+
+          <TextField
+            fullWidth
+            label="Base URL"
+            value={formData.baseUrl}
+            onChange={(e) => setFormData(prev => ({ ...prev, baseUrl: e.target.value }))}
+            margin="normal"
+            placeholder="https://api.example.com"
+            helperText="Optional base URL for the API"
+          />
+        </Box>
+
+        <Typography variant="h6" gutterBottom>
+          OpenAPI Schema
+        </Typography>
+
+        <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)} sx={{ mb: 2 }}>
+          <Tab label="Paste/Edit JSON" />
+          <Tab label="Upload File" icon={<UploadFileIcon />} />
+          <Tab label="Load from URL" icon={<LinkIcon />} />
+        </Tabs>
+
+        <TabPanel value={activeTab} index={0}>
+          <TextField
+            fullWidth
+            multiline
+            rows={12}
+            label="OpenAPI Schema (JSON)"
+            value={formData.schemaText}
+            onChange={(e) => handleSchemaTextChange(e.target.value)}
+            placeholder="Paste your OpenAPI schema JSON here..."
+            variant="outlined"
+          />
+        </TabPanel>
+
+        <TabPanel value={activeTab} index={1}>
+          <Button
+            variant="contained"
+            component="label"
+            fullWidth
+            startIcon={<UploadFileIcon />}
+            sx={{ mb: 2 }}
+          >
+            Upload OpenAPI Schema (JSON)
+            <input
+              type="file"
+              hidden
+              accept=".json"
+              onChange={handleFileUpload}
+            />
+          </Button>
+          
+          {parsedSchema && (
+            <Alert severity="success">
+              Schema loaded successfully: {formData.title}
+            </Alert>
+          )}
+        </TabPanel>
+
+        <TabPanel value={activeTab} index={2}>
+          <TextField
+            fullWidth
+            label="OpenAPI Schema URL"
+            value={formData.schemaUrl}
+            onChange={(e) => setFormData(prev => ({ ...prev, schemaUrl: e.target.value }))}
+            placeholder="https://api.example.com/openapi.json"
+            margin="normal"
+          />
+          <Button
+            variant="contained"
+            onClick={handleUrlLoad}
+            disabled={loading || !formData.schemaUrl}
+            fullWidth
+            sx={{ mt: 1 }}
+          >
+            {loading ? <CircularProgress size={24} /> : 'Load Schema'}
+          </Button>
+        </TabPanel>
+
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {parsedSchema && (
+          <Alert severity="success" sx={{ mt: 2 }}>
+            Schema parsed successfully! Found {parseOpenAPISchema(parsedSchema).operations.length} operations.
+          </Alert>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={handleClose} disabled={saving}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSave}
+          variant="contained"
+          disabled={saving || !parsedSchema}
+        >
+          {saving ? (
+            <CircularProgress size={20} />
+          ) : (
+            isEditing ? 'Update Schema' : 'Save Schema'
+          )}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/ProjectOpenAPIDialog.tsx
+++ b/frontend/src/components/ProjectOpenAPIDialog.tsx
@@ -1,0 +1,339 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  List,
+  ListItem,
+  ListItemText,
+  ListItemSecondaryAction,
+  IconButton,
+  Fab,
+  Typography,
+  Box,
+  Chip,
+  Alert,
+  Snackbar,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  Divider,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import ApiIcon from '@mui/icons-material/Api';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import { ProjectOpenAPISchema, Folder } from '../../../shared/src/types';
+import { api } from '../services/api';
+import OpenAPISchemaDialog from './OpenAPISchemaDialog';
+import OpenAPIGenerateFlowsDialog from './OpenAPIGenerateFlowsDialog';
+
+interface ProjectOpenAPIDialogProps {
+  open: boolean;
+  onClose: () => void;
+  projectId: string;
+  projectName: string;
+  projectFolders: Folder[];
+}
+
+export default function ProjectOpenAPIDialog({
+  open,
+  onClose,
+  projectId,
+  projectName,
+  projectFolders,
+}: ProjectOpenAPIDialogProps) {
+  const [schemas, setSchemas] = useState<ProjectOpenAPISchema[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [schemaDialogOpen, setSchemaDialogOpen] = useState(false);
+  const [generateDialogOpen, setGenerateDialogOpen] = useState(false);
+  const [editingSchema, setEditingSchema] = useState<ProjectOpenAPISchema | null>(null);
+  const [selectedSchema, setSelectedSchema] = useState<ProjectOpenAPISchema | null>(null);
+  const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+  const [menuSchemaId, setMenuSchemaId] = useState<string | null>(null);
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity?: 'success' | 'error' }>({
+    open: false,
+    message: '',
+  });
+
+  useEffect(() => {
+    if (open) {
+      loadSchemas();
+    }
+  }, [open, projectId]);
+
+  const loadSchemas = async () => {
+    try {
+      setLoading(true);
+      const data = await api.getProjectOpenAPISchemas(projectId);
+      setSchemas(data);
+    } catch (error) {
+      console.error('Failed to load OpenAPI schemas:', error);
+      setSnackbar({
+        open: true,
+        message: 'Failed to load OpenAPI schemas',
+        severity: 'error',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAddSchema = () => {
+    setEditingSchema(null);
+    setSchemaDialogOpen(true);
+  };
+
+  const handleEditSchema = (schema: ProjectOpenAPISchema) => {
+    setEditingSchema(schema);
+    setSchemaDialogOpen(true);
+    handleCloseMenu();
+  };
+
+  const handleDeleteSchema = async (schemaId: string) => {
+    if (!window.confirm('Are you sure you want to delete this OpenAPI schema?')) {
+      return;
+    }
+
+    try {
+      await api.deleteProjectOpenAPISchema(projectId, schemaId);
+      await loadSchemas();
+      setSnackbar({
+        open: true,
+        message: 'Schema deleted successfully',
+        severity: 'success',
+      });
+    } catch (error) {
+      console.error('Failed to delete schema:', error);
+      setSnackbar({
+        open: true,
+        message: 'Failed to delete schema',
+        severity: 'error',
+      });
+    }
+    handleCloseMenu();
+  };
+
+  const handleGenerateFlows = (schema: ProjectOpenAPISchema) => {
+    setSelectedSchema(schema);
+    setGenerateDialogOpen(true);
+    handleCloseMenu();
+  };
+
+  const handleSchemaDialogClose = (saved?: boolean) => {
+    setSchemaDialogOpen(false);
+    setEditingSchema(null);
+    if (saved) {
+      loadSchemas();
+    }
+  };
+
+  const handleGenerateDialogClose = (generated?: boolean) => {
+    setGenerateDialogOpen(false);
+    setSelectedSchema(null);
+    if (generated) {
+      setSnackbar({
+        open: true,
+        message: 'Flows generated successfully',
+        severity: 'success',
+      });
+    }
+  };
+
+  const handleOpenMenu = (event: React.MouseEvent<HTMLElement>, schemaId: string) => {
+    setMenuAnchor(event.currentTarget);
+    setMenuSchemaId(schemaId);
+  };
+
+  const handleCloseMenu = () => {
+    setMenuAnchor(null);
+    setMenuSchemaId(null);
+  };
+
+  const formatDate = (date: Date) => {
+    return new Date(date).toLocaleDateString();
+  };
+
+  return (
+    <>
+      <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+        <DialogTitle>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <ApiIcon />
+            OpenAPI Schemas - {projectName}
+          </Box>
+        </DialogTitle>
+
+        <DialogContent>
+          {schemas.length === 0 && !loading ? (
+            <Box sx={{ textAlign: 'center', py: 4 }}>
+              <ApiIcon sx={{ fontSize: 64, color: 'text.secondary', mb: 2 }} />
+              <Typography variant="h6" color="text.secondary" gutterBottom>
+                No OpenAPI Schemas
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+                Add OpenAPI schemas to reuse them across multiple flows in this project.
+              </Typography>
+              <Button variant="contained" startIcon={<AddIcon />} onClick={handleAddSchema}>
+                Add Schema
+              </Button>
+            </Box>
+          ) : (
+            <List>
+              {schemas.map((schema, index) => (
+                <React.Fragment key={schema.id}>
+                  {index > 0 && <Divider />}
+                  <ListItem>
+                    <ListItemIcon>
+                      <ApiIcon color="primary" />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+                          <Typography variant="subtitle1" component="span">
+                            {schema.name}
+                          </Typography>
+                          <Chip
+                            label={`v${schema.version}`}
+                            size="small"
+                            variant="outlined"
+                            color="primary"
+                          />
+                        </Box>
+                      }
+                      secondary={
+                        <Box>
+                          <Typography variant="body2" color="text.secondary">
+                            {schema.title}
+                          </Typography>
+                          {schema.description && (
+                            <Typography variant="caption" color="text.secondary">
+                              {schema.description}
+                            </Typography>
+                          )}
+                          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+                            Created: {formatDate(schema.createdAt)}
+                            {schema.baseUrl && ` • Base URL: ${schema.baseUrl}`}
+                          </Typography>
+                        </Box>
+                      }
+                    />
+                    <ListItemSecondaryAction>
+                      <IconButton
+                        edge="end"
+                        onClick={(e) => handleOpenMenu(e, schema.id)}
+                        size="small"
+                      >
+                        <MoreVertIcon />
+                      </IconButton>
+                    </ListItemSecondaryAction>
+                  </ListItem>
+                </React.Fragment>
+              ))}
+            </List>
+          )}
+
+          {schemas.length > 0 && (
+            <Box sx={{ position: 'relative', height: 80 }}>
+              <Fab
+                color="primary"
+                size="medium"
+                onClick={handleAddSchema}
+                sx={{
+                  position: 'absolute',
+                  bottom: 16,
+                  right: 16,
+                }}
+              >
+                <AddIcon />
+              </Fab>
+            </Box>
+          )}
+        </DialogContent>
+
+        <DialogActions>
+          <Button onClick={onClose}>Close</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Menu
+        anchorEl={menuAnchor}
+        open={Boolean(menuAnchor)}
+        onClose={handleCloseMenu}
+      >
+        <MenuItem
+          onClick={() => {
+            const schema = schemas.find(s => s.id === menuSchemaId);
+            if (schema) handleEditSchema(schema);
+          }}
+        >
+          <ListItemIcon>
+            <EditIcon fontSize="small" />
+          </ListItemIcon>
+          Edit Schema
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            const schema = schemas.find(s => s.id === menuSchemaId);
+            if (schema) handleGenerateFlows(schema);
+          }}
+        >
+          <ListItemIcon>
+            <PlayArrowIcon fontSize="small" />
+          </ListItemIcon>
+          Generate Flows
+        </MenuItem>
+        <Divider />
+        <MenuItem
+          onClick={() => {
+            if (menuSchemaId) handleDeleteSchema(menuSchemaId);
+          }}
+          sx={{ color: 'error.main' }}
+        >
+          <ListItemIcon>
+            <DeleteIcon fontSize="small" color="error" />
+          </ListItemIcon>
+          Delete Schema
+        </MenuItem>
+      </Menu>
+
+      {schemaDialogOpen && (
+        <OpenAPISchemaDialog
+          open={schemaDialogOpen}
+          onClose={handleSchemaDialogClose}
+          projectId={projectId}
+          schema={editingSchema}
+        />
+      )}
+
+      {generateDialogOpen && selectedSchema && (
+        <OpenAPIGenerateFlowsDialog
+          open={generateDialogOpen}
+          onClose={handleGenerateDialogClose}
+          projectId={projectId}
+          schema={selectedSchema}
+          projectFolders={projectFolders}
+        />
+      )}
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={6000}
+        onClose={() => setSnackbar({ ...snackbar, open: false })}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={() => setSnackbar({ ...snackbar, open: false })}
+          severity={snackbar.severity || 'info'}
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}

--- a/frontend/src/pages/FlowEditor.tsx
+++ b/frontend/src/pages/FlowEditor.tsx
@@ -1518,6 +1518,7 @@ export default function FlowEditor() {
           open={openAPIDialogOpen}
           onClose={() => uiActions.setOpenAPIDialogOpen(false)}
           onImport={handleOpenAPIImport}
+          projectId={searchParams.get('projectId') || undefined}
         />
       </ComponentErrorBoundary>
       

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -29,9 +29,11 @@ import AddIcon from '@mui/icons-material/Add';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import DownloadIcon from '@mui/icons-material/Download';
 import UploadIcon from '@mui/icons-material/Upload';
+import ApiIcon from '@mui/icons-material/Api';
 import { Project, Folder } from '../../../shared/src/types';
 import { api } from '../services/api';
 import LoadingOverlay from '../components/LoadingOverlay';
+import ProjectOpenAPIDialog from '../components/ProjectOpenAPIDialog';
 
 export default function Projects() {
   const [projects, setProjects] = useState<Project[]>([]);
@@ -48,6 +50,8 @@ export default function Projects() {
   const [, setImportingProjectId] = useState<string>('');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [openApiDialogOpen, setOpenApiDialogOpen] = useState(false);
+  const [selectedProjectForApi, setSelectedProjectForApi] = useState<Project | null>(null);
 
   useEffect(() => {
     loadProjects();
@@ -232,6 +236,16 @@ export default function Projects() {
     setImportingProjectId('');
   };
 
+  const handleOpenApiDialog = (project: Project) => {
+    setSelectedProjectForApi(project);
+    setOpenApiDialogOpen(true);
+  };
+
+  const handleCloseApiDialog = () => {
+    setOpenApiDialogOpen(false);
+    setSelectedProjectForApi(null);
+  };
+
   return (
     <Box className="animate-fadeIn" sx={{ position: 'relative' }}>
       <LoadingOverlay open={loading} message="Loading projects..." />
@@ -397,6 +411,14 @@ export default function Projects() {
                 </Button>
                 <Button
                   size="small"
+                  startIcon={<ApiIcon />}
+                  onClick={() => handleOpenApiDialog(project)}
+                  sx={{ color: '#9c27b0' }}
+                >
+                  Schemas
+                </Button>
+                <Button
+                  size="small"
                   startIcon={<DeleteIcon />}
                   onClick={() => handleDeleteProject(project.id)}
                   sx={{ color: '#f5576c' }}
@@ -495,6 +517,17 @@ export default function Projects() {
           onChange={(e) => handleImportFile(e, project.id)}
         />
       ))}
+
+      {/* OpenAPI Schema Dialog */}
+      {selectedProjectForApi && (
+        <ProjectOpenAPIDialog
+          open={openApiDialogOpen}
+          onClose={handleCloseApiDialog}
+          projectId={selectedProjectForApi.id}
+          projectName={selectedProjectForApi.name}
+          projectFolders={folders[selectedProjectForApi.id] || []}
+        />
+      )}
     </Box>
   );
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { TestFlow, TestRun, Environment, EnvironmentVariable, Project, Folder, Organization, Team, TeamUser, TeamUserWithDetails, ProjectTeam } from '../../../shared/src/types';
+import { TestFlow, TestRun, Environment, EnvironmentVariable, Project, Folder, Organization, Team, TeamUser, TeamUserWithDetails, ProjectTeam, ProjectOpenAPISchema } from '../../../shared/src/types';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
@@ -178,6 +178,41 @@ export const api = {
 
   async importProject(projectId: string, data: any): Promise<any> {
     const response = await apiClient.post(`/projects/${projectId}/import`, data);
+    return response.data;
+  },
+
+  // Project OpenAPI Schemas
+  async getProjectOpenAPISchemas(projectId: string): Promise<ProjectOpenAPISchema[]> {
+    const response = await apiClient.get(`/projects/${projectId}/openapi-schemas`);
+    return response.data;
+  },
+
+  async createProjectOpenAPISchema(projectId: string, schema: Partial<ProjectOpenAPISchema>): Promise<ProjectOpenAPISchema> {
+    const response = await apiClient.post(`/projects/${projectId}/openapi-schemas`, schema);
+    return response.data;
+  },
+
+  async updateProjectOpenAPISchema(projectId: string, schemaId: string, schema: Partial<ProjectOpenAPISchema>): Promise<ProjectOpenAPISchema> {
+    const response = await apiClient.put(`/projects/${projectId}/openapi-schemas/${schemaId}`, schema);
+    return response.data;
+  },
+
+  async deleteProjectOpenAPISchema(projectId: string, schemaId: string): Promise<void> {
+    await apiClient.delete(`/projects/${projectId}/openapi-schemas/${schemaId}`);
+  },
+
+  async generateFlowsFromOpenAPISchema(
+    projectId: string,
+    schemaId: string,
+    selectedOperations: string[],
+    baseUrlOverride?: string,
+    folderId?: string
+  ): Promise<TestFlow[]> {
+    const response = await apiClient.post(`/projects/${projectId}/openapi-schemas/${schemaId}/generate-flows`, {
+      selectedOperations,
+      baseUrlOverride,
+      folderId
+    });
     return response.data;
   },
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -17,5 +17,6 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
+  "exclude": ["../shared"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12063,7 +12063,11 @@
     },
     "shared": {
       "version": "1.0.0",
+      "dependencies": {
+        "uuid": "^9.0.0"
+      },
       "devDependencies": {
+        "@types/uuid": "^9.0.0",
         "typescript": "^5.3.3"
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "react-flow-renderer": "^10.3.17",
         "react-router-dom": "^6.30.1",
         "socket.io-client": "^4.7.2",
-        "uuid": "^11.1.0"
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.5",
@@ -77,11 +77,21 @@
         "@types/react": "^18.2.45",
         "@types/react-dom": "^18.2.18",
         "@vitejs/plugin-react": "^4.2.1",
-        "@vitest/coverage-v8": "^1.0.4",
+        "@vitest/coverage-v8": "^3.2.4",
         "jsdom": "^23.0.1",
         "typescript": "^5.3.3",
-        "vite": "^5.0.10",
-        "vitest": "^1.0.4"
+        "vite": "^6.3.5",
+        "vitest": "^3.2.4"
+      }
+    },
+    "frontend/node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "frontend/node_modules/@types/uuid": {
@@ -89,6 +99,356 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
+    },
+    "frontend/node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "frontend/node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "frontend/node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "frontend/node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "frontend/node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "frontend/node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "frontend/node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "frontend/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "frontend/node_modules/chai": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "frontend/node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "frontend/node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "frontend/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "frontend/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "frontend/node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "frontend/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "frontend/node_modules/loupe": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
+      "integrity": "sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "frontend/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "frontend/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "frontend/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "frontend/node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "frontend/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "frontend/node_modules/strip-literal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "frontend/node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "frontend/node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "frontend/node_modules/tinyspy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "frontend/node_modules/uuid": {
       "version": "11.1.0",
@@ -101,6 +461,192 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "frontend/node_modules/vite": {
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "frontend/node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "frontend/node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "frontend/node_modules/yaml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1375,6 +1921,109 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -2054,6 +2703,17 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -2685,6 +3345,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -2973,6 +3643,13 @@
         "@types/d3-interpolate": "*",
         "@types/d3-selection": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3308,147 +3985,64 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
       }
     },
-    "node_modules/@vitest/coverage-v8": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
-      "integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.1",
-        "@bcoe/v8-coverage": "^0.2.3",
-        "debug": "^4.3.4",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-lib-source-maps": "^5.0.4",
-        "istanbul-reports": "^3.1.6",
-        "magic-string": "^0.30.5",
-        "magicast": "^0.3.3",
-        "picocolors": "^1.0.0",
-        "std-env": "^3.5.0",
-        "strip-literal": "^2.0.0",
-        "test-exclude": "^6.0.0"
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "1.6.1"
-      }
-    },
-    "node_modules/@vitest/coverage-v8/node_modules/istanbul-lib-source-maps": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
-      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.23",
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0"
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
-      "engines": {
-        "node": ">=10"
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@vitest/expect": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
-      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+    "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "1.6.1",
-        "@vitest/utils": "1.6.1",
-        "chai": "^4.3.10"
+        "tinyspy": "^4.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/runner": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
-      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "1.6.1",
-        "p-limit": "^5.0.0",
-        "pathe": "^1.1.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner/node_modules/p-limit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
-      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@vitest/runner/node_modules/yocto-queue": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+    "node_modules/@vitest/mocker/node_modules/tinyspy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/@vitest/snapshot": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
-      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "magic-string": "^0.30.5",
-        "pathe": "^1.1.1",
-        "pretty-format": "^29.7.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/spy": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
-      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^2.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/utils": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
-      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "diff-sequences": "^29.6.3",
-        "estree-walker": "^3.0.3",
-        "loupe": "^2.3.7",
-        "pretty-format": "^29.7.0"
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -3472,32 +4066,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -3675,15 +4243,24 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.3.tgz",
+      "integrity": "sha512-MuXMrSLVVoA6sYN/6Hke18vMzrT4TZNbZIj/hvh0fnYFpO+/kFXcLIaiPwXXWaQUPg4yJD8fj+lfJ7/1EBconw==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": "*"
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^9.0.1"
       }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -4257,35 +4834,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chai": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
-      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/chai/node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4324,19 +4872,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chownr": {
@@ -4515,13 +5050,6 @@
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
-    },
-    "node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
@@ -4905,19 +5433,6 @@
         }
       }
     },
-    "node_modules/deep-eql": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/deep-equal": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
@@ -5121,6 +5636,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -5384,6 +5906,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -5570,6 +6099,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+      "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -5811,6 +6350,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
@@ -5962,16 +6531,6 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -6889,6 +7448,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jake": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
@@ -7728,23 +8303,6 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
-    "node_modules/local-pkg": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
-      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mlly": "^1.7.3",
-        "pkg-types": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -7823,16 +8381,6 @@
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
       }
     },
     "node_modules/lru-cache": {
@@ -8253,26 +8801,6 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
-    "node_modules/mlly": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
-      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.14.0",
-        "pathe": "^2.0.1",
-        "pkg-types": "^1.3.0",
-        "ufo": "^1.5.4"
-      }
-    },
-    "node_modules/mlly/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/mongodb": {
       "version": "6.17.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.17.0.tgz",
@@ -8691,6 +9219,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8779,6 +9314,40 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
@@ -8792,23 +9361,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/picocolors": {
@@ -8852,25 +9404,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
-      }
-    },
-    "node_modules/pkg-types/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/playwright": {
       "version": "1.53.1",
@@ -10270,11 +10803,41 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -10324,26 +10887,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/strip-literal": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
-      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/strip-literal/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/stylis": {
       "version": "4.2.0",
@@ -10537,20 +11080,62 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tinypool": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
-      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/tinyspy": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
-      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10741,6 +11326,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -10806,13 +11392,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/ufo": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -10975,6 +11554,7 @@
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -11029,29 +11609,6 @@
         }
       }
     },
-    "node_modules/vite-node": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
-      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.3.4",
-        "pathe": "^1.1.1",
-        "picocolors": "^1.0.0",
-        "vite": "^5.0.0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -11065,6 +11622,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11082,6 +11640,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11099,6 +11658,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11116,6 +11676,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11133,6 +11694,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11150,6 +11712,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11167,6 +11730,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11184,6 +11748,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11201,6 +11766,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11218,6 +11784,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11235,6 +11802,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11252,6 +11820,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11269,6 +11838,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11286,6 +11856,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11303,6 +11874,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11320,6 +11892,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11337,6 +11910,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11354,6 +11928,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11371,6 +11946,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11388,6 +11964,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11405,6 +11982,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11422,6 +12000,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11439,6 +12018,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11450,6 +12030,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -11493,218 +12074,9 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/vitest": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
-      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "1.6.1",
-        "@vitest/runner": "1.6.1",
-        "@vitest/snapshot": "1.6.1",
-        "@vitest/spy": "1.6.1",
-        "@vitest/utils": "1.6.1",
-        "acorn-walk": "^8.3.2",
-        "chai": "^4.3.10",
-        "debug": "^4.3.4",
-        "execa": "^8.0.1",
-        "local-pkg": "^0.5.0",
-        "magic-string": "^0.30.5",
-        "pathe": "^1.1.1",
-        "picocolors": "^1.0.0",
-        "std-env": "^3.5.0",
-        "strip-literal": "^2.0.0",
-        "tinybench": "^2.5.1",
-        "tinypool": "^0.8.3",
-        "vite": "^5.0.0",
-        "vite-node": "1.6.1",
-        "why-is-node-running": "^2.2.2"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "1.6.1",
-        "@vitest/ui": "1.6.1",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/vitest/node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.17.0"
-      }
-    },
-    "node_modules/vitest/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/vitest/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -11893,6 +12265,25 @@
       }
     },
     "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",

--- a/shared/package.json
+++ b/shared/package.json
@@ -7,7 +7,11 @@
   "scripts": {
     "build": "tsc"
   },
+  "dependencies": {
+    "uuid": "^9.0.0"
+  },
   "devDependencies": {
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "@types/uuid": "^9.0.0"
   }
 }

--- a/shared/src/openApiParser.ts
+++ b/shared/src/openApiParser.ts
@@ -1,0 +1,181 @@
+import { TestStep, HttpStepConfig } from './types';
+import { v4 as uuidv4 } from 'uuid';
+
+export interface OpenAPIOperation {
+  path: string;
+  method: string;
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  parameters?: any[];
+  requestBody?: any;
+  responses?: any;
+}
+
+export interface ParsedOpenAPI {
+  title: string;
+  version: string;
+  servers: string[];
+  operations: OpenAPIOperation[];
+}
+
+export function parseOpenAPISchema(schema: any): ParsedOpenAPI {
+  const result: ParsedOpenAPI = {
+    title: schema.info?.title || 'Untitled API',
+    version: schema.info?.version || '1.0.0',
+    servers: [],
+    operations: []
+  };
+
+  // Extract servers
+  if (schema.servers && Array.isArray(schema.servers)) {
+    result.servers = schema.servers.map((server: any) => server.url);
+  }
+
+  // Extract operations from paths
+  if (schema.paths) {
+    Object.entries(schema.paths).forEach(([path, pathItem]: [string, any]) => {
+      const methods = ['get', 'post', 'put', 'delete', 'patch'];
+      
+      methods.forEach(method => {
+        if (pathItem[method]) {
+          const operation = pathItem[method];
+          result.operations.push({
+            path,
+            method: method.toUpperCase(),
+            operationId: operation.operationId,
+            summary: operation.summary,
+            description: operation.description,
+            parameters: operation.parameters || [],
+            requestBody: operation.requestBody,
+            responses: operation.responses
+          });
+        }
+      });
+    });
+  }
+
+  return result;
+}
+
+export function generateStepsFromOpenAPI(
+  parsedAPI: ParsedOpenAPI, 
+  selectedOperations: string[],
+  baseUrl?: string
+): TestStep[] {
+  const steps: TestStep[] = [];
+  const server = baseUrl || parsedAPI.servers[0] || '';
+
+  parsedAPI.operations
+    .filter(op => selectedOperations.includes(`${op.method} ${op.path}`))
+    .forEach(operation => {
+      const stepId = uuidv4();
+      const stepName = operation.summary || 
+        operation.operationId || 
+        `${operation.method} ${operation.path}`;
+
+      // Build URL with path parameters as placeholders
+      let url = `${server}${operation.path}`;
+      
+      // Replace path parameters with placeholder syntax
+      if (operation.parameters) {
+        operation.parameters
+          .filter((param: any) => param.in === 'path')
+          .forEach((param: any) => {
+            url = url.replace(`{${param.name}}`, `{{${param.name}}}`);
+          });
+      }
+
+      // Build headers
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json'
+      };
+
+      // Add header parameters
+      if (operation.parameters) {
+        operation.parameters
+          .filter((param: any) => param.in === 'header')
+          .forEach((param: any) => {
+            headers[param.name] = param.example || `{{${param.name}}}`;
+          });
+      }
+
+      // Build query parameters
+      const queryParams: string[] = [];
+      if (operation.parameters) {
+        operation.parameters
+          .filter((param: any) => param.in === 'query')
+          .forEach((param: any) => {
+            queryParams.push(`${param.name}={{${param.name}}}`);
+          });
+      }
+
+      if (queryParams.length > 0) {
+        url += '?' + queryParams.join('&');
+      }
+
+      // Build request body
+      let body = null;
+      if (operation.requestBody?.content?.['application/json']?.schema) {
+        body = generateExampleFromSchema(operation.requestBody.content['application/json'].schema);
+      }
+
+      const config: HttpStepConfig = {
+        method: operation.method as any,
+        url,
+        headers,
+        body,
+        timeout: 30000,
+        retries: 0
+      };
+
+      steps.push({
+        id: stepId,
+        name: stepName,
+        type: 'http',
+        config
+      });
+    });
+
+  return steps;
+}
+
+function generateExampleFromSchema(schema: any): any {
+  if (!schema) return null;
+
+  switch (schema.type) {
+    case 'object':
+      const obj: any = {};
+      if (schema.properties) {
+        Object.entries(schema.properties).forEach(([key, propSchema]: [string, any]) => {
+          obj[key] = generateExampleFromSchema(propSchema);
+        });
+      }
+      return obj;
+
+    case 'array':
+      return [generateExampleFromSchema(schema.items)];
+
+    case 'string':
+      if (schema.example) return schema.example;
+      if (schema.enum) return schema.enum[0];
+      if (schema.format === 'email') return 'user@example.com';
+      if (schema.format === 'date') return '2024-01-01';
+      if (schema.format === 'date-time') return '2024-01-01T00:00:00Z';
+      if (schema.format === 'uuid') return '123e4567-e89b-12d3-a456-426614174000';
+      return 'string';
+
+    case 'number':
+    case 'integer':
+      if (schema.example) return schema.example;
+      if (schema.minimum !== undefined) return schema.minimum;
+      return 0;
+
+    case 'boolean':
+      if (schema.example !== undefined) return schema.example;
+      return true;
+
+    default:
+      return null;
+  }
+}

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -168,6 +168,20 @@ export interface Project {
   organizationId: string;
   name: string;
   description?: string;
+  openApiSchemas?: ProjectOpenAPISchema[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ProjectOpenAPISchema {
+  id: string;
+  projectId: string;
+  name: string;
+  description?: string;
+  version: string;
+  title: string;
+  baseUrl?: string;
+  schema: any; // The actual OpenAPI schema object
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
## Summary
- Implements project-wide OpenAPI schema storage and management
- Addresses Issue #3: OpenAPI schema import should be project wide not flow wide
- Provides foundation for reusable OpenAPI schemas across multiple flows

## Backend Implementation
- Added ProjectOpenAPISchema type and extended Project interface
- Created database tables/collections for schema storage
- Implemented full CRUD operations for OpenAPI schemas
- Added API endpoints for schema management and flow generation
- Moved openApiParser to shared directory for reuse

## Database Changes
- SQLite: Added project_openapi_schemas table with foreign key constraints
- MongoDB: Added projectOpenAPISchemas collection
- Support for schema metadata and full OpenAPI document storage

## API Endpoints
- `GET /projects/:id/openapi-schemas` - List project schemas
- `POST /projects/:id/openapi-schemas` - Create new schema
- `PUT /projects/:id/openapi-schemas/:schemaId` - Update schema
- `DELETE /projects/:id/openapi-schemas/:schemaId` - Delete schema
- `POST /projects/:id/openapi-schemas/:schemaId/generate-flows` - Generate flows

## Test Plan
- [x] Backend builds successfully with new types and endpoints
- [x] Database schema updates work for both SQLite and MongoDB
- [x] OpenAPI parser successfully moved to shared directory
- [ ] Frontend UI components for schema management (future PR)
- [ ] Integration with existing OpenAPI import dialog (future PR)

This PR provides the foundational backend infrastructure. Future PRs will add UI components for managing project-wide schemas and integrating with the flow creation workflow.